### PR TITLE
Names instead of IDs

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -63,7 +63,8 @@ module Fluent
           if data[:key] =~ /^(?:cpuacct|blkio|memory_stat_pg)/
             data[:type] = 'counter'
           end
-          data["source"] = "#{@tag_prefix}:#{@hostname}:#{id}"
+          containerName = `docker inspect --format '{{ .Name }}' #{id}`.strip[1..-1]
+          data["source"] = "#{@tag_prefix}:#{@hostname}:#{containerName}"
           mes.add(time, data)
         end
         Engine.emit_stream(tag, mes)


### PR DESCRIPTION
I give names to all my docker containers, and in the fluentd data streams I would like to see those names rather than the meaningless IDs (for humans), especially since I then send the data to librato.

This is the first time I touch ruby, I don't know the first thing about the language, but with the help of StackOverflow I think I was able to make a meaningful improvement to your plugin. If you don't agree, no hard feelings :-)
