### PR TITLE
add gauge metric type, fix kiyoto/fluent-plugin-docker-metrics#4

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -62,6 +62,8 @@ module Fluent
           # TODO: address this more elegantly
           if data['key'] =~ /^(?:cpuacct|blkio|memory_stat_pg)/
             data['type'] = 'counter'
+          else
+            data['type'] = 'gauge'
           end
           data["source"] = "#{@tag_prefix}:#{@hostname}:#{id}"
           mes.add(time, data)


### PR DESCRIPTION
set the type field as 'gauge' when it's not a counter
