### PR TITLE
collect metrics of docker with systemd

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -53,9 +53,12 @@ module Fluent
     end
 
     def emit_container_metric(id, name, metric_type, metric_filename, opts = {})
-      path = @with_systemd ?
-        "#{@cgroup_path}/#{metric_type}/system.slice/docker-#{id}.scope/#{metric_filename}" :
-      "#{@cgroup_path}/#{metric_type}/docker/#{id}/#{metric_filename}"
+
+      if @with_systemd
+        path = "#{@cgroup_path}/#{metric_type}/system.slice/docker-#{id}.scope/#{metric_filename}"
+      else
+        path = "#{@cgroup_path}/#{metric_type}/docker/#{id}/#{metric_filename}"
+      end
 
       if File.exists?(path)
         # the order of these two if's matters


### PR DESCRIPTION
Some Linux distributions (REHL/CentOS/CoreOS/etc...) use systemd to start the Docker daemon.
In such cases, docker metrics are not in `/sys/fs/cgroups/<metric_type>/docker/<container_id>/` but in
 `/sys/fs/cgroups/system.slice/docker-<container_id>.scope/<metric_filename>`.
