### PR TITLE
Fixing name \ substitution

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -82,7 +82,7 @@ module Fluent
           end
           data["hostname"] = @hostname
           data["id"] = id
-          data["name"] = name.sub!(/^\//, '')
+          data["name"] = name.sub(/^\//, '')
           mes.add(time, data)
         end
         Engine.emit_stream(tag, mes)


### PR DESCRIPTION
The name.sub! was returning null instead of the proper value. This is leaving the current master broken.