### PR TITLE
"name" field should be basename, which doesn't include link information

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -48,7 +48,7 @@ module Fluent
 
     def list_container_ids
       Docker::Container.all.map do |container|
-        [container.id, container.info["Names"].first]
+        [container.id, container.json["Name"]]
       end
     end
 


### PR DESCRIPTION
When we link some containers with another, sometimes this plugin generate fields which are dfficult to deal with (like `containerA/containerB`).
As shown in the following sample, this happens for a reason of using `Docker::Container.info` method.
With using `Docker::Container.json`, we can get basename of containers.

```
Docker::Container.all.map{|container| container.info['Names'] }
=> [["/fluentd"],  ["/fluentd/norikra", "/norikra"]]

Docker::Container.all.map{|container| container.json['Name'] }
=> ["/fluentd", "/norikra"]
```
