### PR TITLE
Use testing frameworks explicitly in gem spec and use them

### DIFF
--- a/fluent-plugin-docker-metrics.gemspec
+++ b/fluent-plugin-docker-metrics.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fakefs"
+  spec.add_development_dependency "test-unit", "~> 3.1"
+  spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "docker-api"
 end

--- a/test/test_in_docker_metrics.rb
+++ b/test/test_in_docker_metrics.rb
@@ -1,8 +1,9 @@
 require 'fluent/test'
 require 'fluent/plugin/in_docker_metrics'
 require 'fakefs/safe'
+require 'minitest/autorun'
 
-class TestDockerMetricsInput < MiniTest::Unit::TestCase
+class TestDockerMetricsInput < Minitest::Test
   METRICS = [
       ['memory', 'memory.stat'], 
       ['cpuacct', 'cpuacct.stat'], 


### PR DESCRIPTION
Because Ruby 2.2 does not bundle minitest with test-unit compatible
layer.
So, we should write testing framework dependency in gemspec and require
them.

Related to #12.