### PR TITLE
Add a missing require

### DIFF
--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class DockerMetricsInput < Input
     Plugin.register_input('docker_metrics', self)


### PR DESCRIPTION
requiring 'fluent/input' is needed for working with Fluentd v0.14.