### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-docker-metrics.gemspec
+++ b/fluent-plugin-docker-metrics.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakefs"
   spec.add_development_dependency "test-unit", "~> 3.1"
   spec.add_development_dependency "minitest", "~> 5.8"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.11", "< 2"]
   spec.add_runtime_dependency "docker-api"
 end

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -1,3 +1,5 @@
+require 'socket'
+require 'docker'
 require 'fluent/plugin/input'
 
 module Fluent::Plugin
@@ -18,8 +20,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'socket'
-      require 'docker'
       @hostname = Socket.gethostname
       @with_systemd = File.exists?("#{@cgroup_path}/systemd")
     end

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -8,11 +8,6 @@ module Fluent::Plugin
 
     helpers :timer
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Engine }
-    end
-
     config_param :cgroup_path, :string, :default => '/sys/fs/cgroup'
     config_param :stats_interval, :time, :default => 60 # every minute
     config_param :tag_prefix, :string, :default => "docker"

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -67,7 +67,7 @@ module Fluent::Plugin
         path = "#{@cgroup_path}/#{metric_type}/docker/#{id}/#{metric_filename}"
       end
 
-      if File.exists?(path)
+      if File.exist?(path)
         # the order of these two if's matters
         if metric_filename == 'blkio.sectors'
           parser = BlkioSectorsParser.new(path, metric_filename.gsub('.', '_'))

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -96,21 +96,6 @@ module Fluent::Plugin
       super
     end
 
-    class TimerWatcher < Coolio::TimerWatcher
-
-      def initialize(interval, repeat, log, &callback)
-        @callback = callback
-        @log = log
-        super(interval, repeat)
-      end
-      def on_timer
-        @callback.call
-      rescue
-        @log.error $!.to_s
-        @log.error_backtrace
-      end
-    end
-
     class CGroupStatsParser
       def initialize(path, metric_type)
         raise ConfigError if not File.exists?(path)

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -44,12 +44,12 @@ module Fluent::Plugin
     def get_metrics
       ids = @container_ids || list_container_ids
       ids.each do |id, name|
-        emit_container_metric(id, name, 'memory', 'memory.stat') 
-        emit_container_metric(id, name, 'cpuacct', 'cpuacct.stat') 
-        emit_container_metric(id, name, 'blkio', 'blkio.io_serviced') 
-        emit_container_metric(id, name, 'blkio', 'blkio.io_service_bytes') 
-        emit_container_metric(id, name, 'blkio', 'blkio.io_queued') 
-        emit_container_metric(id, name, 'blkio', 'blkio.sectors') 
+        emit_container_metric(id, name, 'memory', 'memory.stat')
+        emit_container_metric(id, name, 'cpuacct', 'cpuacct.stat')
+        emit_container_metric(id, name, 'blkio', 'blkio.io_serviced')
+        emit_container_metric(id, name, 'blkio', 'blkio.io_service_bytes')
+        emit_container_metric(id, name, 'blkio', 'blkio.io_queued')
+        emit_container_metric(id, name, 'blkio', 'blkio.sectors')
       end
     end
 
@@ -148,7 +148,7 @@ module Fluent::Plugin
 
     class BlkioStatsParser < CGroupStatsParser
       BlkioLineRegexp = /^(?<major>\d+):(?<minor>\d+) (?<key>[^ ]+) (?<value>\d+)/
-      
+
       def parse_line(line)
         m = BlkioLineRegexp.match(line)
         if m

--- a/lib/fluent/plugin/in_docker_metrics.rb
+++ b/lib/fluent/plugin/in_docker_metrics.rb
@@ -1,8 +1,8 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 
-module Fluent
+module Fluent::Plugin
   class DockerMetricsInput < Input
-    Plugin.register_input('docker_metrics', self)
+    Fluent::Plugin.register_input('docker_metrics', self)
 
     # Define `router` method of v0.12 to support v0.10 or earlier
     unless method_defined?(:router)
@@ -76,9 +76,9 @@ module Fluent
         else
           parser = KeyValueStatsParser.new(path, metric_filename.gsub('.', '_'))
         end
-        time = Engine.now
+        time = Fluent::Engine.now
         tag = "#{@tag_prefix}.#{metric_filename}"
-        mes = MultiEventStream.new
+        mes = Fluent::MultiEventStream.new
         parser.parse_each_line do |data|
           next if not data
           # TODO: address this more elegantly

--- a/test/test_in_docker_metrics.rb
+++ b/test/test_in_docker_metrics.rb
@@ -27,7 +27,7 @@ class TestDockerMetricsInput < Minitest::Test
     metrics = {}
     METRICS.each do |_, file|
       p = "#{File.dirname(File.expand_path(__FILE__))}/data/#{file}"
-      if not File.exists?(p)
+      if not File.exist?(p)
         raise IOError, p
       end
       metrics[file] = File.new(p).read

--- a/test/test_in_docker_metrics.rb
+++ b/test/test_in_docker_metrics.rb
@@ -1,14 +1,15 @@
 require 'fluent/test'
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_docker_metrics'
 require 'fakefs/safe'
 require 'minitest/autorun'
 
 class TestDockerMetricsInput < Minitest::Test
   METRICS = [
-      ['memory', 'memory.stat'], 
-      ['cpuacct', 'cpuacct.stat'], 
-      ['blkio', 'blkio.io_serviced'], 
-      ['blkio', 'blkio.io_service_bytes'], 
+      ['memory', 'memory.stat'],
+      ['cpuacct', 'cpuacct.stat'],
+      ['blkio', 'blkio.io_serviced'],
+      ['blkio', 'blkio.io_service_bytes'],
       ['blkio', 'blkio.io_queued'],
       ['blkio', 'blkio.sectors']
     ]
@@ -29,7 +30,7 @@ class TestDockerMetricsInput < Minitest::Test
       if not File.exists?(p)
         raise IOError, p
       end
-      metrics[file] = File.new(p).read 
+      metrics[file] = File.new(p).read
     end
     metrics
   end
@@ -131,4 +132,4 @@ class TestDockerMetricsInput < Minitest::Test
   def teardown
     FakeFS.deactivate!
   end
-end 
+end

--- a/test/test_in_docker_metrics.rb
+++ b/test/test_in_docker_metrics.rb
@@ -45,7 +45,7 @@ class TestDockerMetricsInput < Minitest::Test
   end
 
   def create_driver
-    Fluent::Test::InputTestDriver.new(Fluent::DockerMetricsInput).configure(%[
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::DockerMetricsInput).configure(%[
       container_ids [["#{@container_id}", "#{@container_name}"]]
       stats_interval 5s
     ])
@@ -53,11 +53,9 @@ class TestDockerMetricsInput < Minitest::Test
 
   def test_outputs
     d = create_driver
-    d.run do
-      sleep 2
-    end
+    d.run(expect_emits: 46, timeout: 5)
 
-    emits = d.emits
+    emits = d.events
     check_metric_type(emits, 'memory.stat', [
         {"key"=>"memory_stat_cache", "value"=>32768},
         {"key"=>"memory_stat_rss", "value"=>471040},


### PR DESCRIPTION
This PR patches should be treated as major update.
Fluentd core development team strongly recommended to use v0.14 API, and I've tried to use v0.14 API in this plugin.

BTW, I'm using Debian stretch (9.0) in development, and I've found that `@with_systemd` mechanism does not work for my Debian environment.

My environment, does not have `"#{@cgroup_path}/#{metric_type}/system.slice/docker-#{id}.scope/#{metric_filename}"` path.
Instead, it has `"#{@cgroup_path}/#{metric_type}/docker/#{id}/#{metric_filename}"` path.
This issue is caused by my misconfiguration?

```log
% ls /lib/systemd/system/docker.service
/lib/systemd/system/docker.service
% ls /etc/init.d/docker
/etc/init.d/docker
% cat /etc/debian_version
9.0
```

Thanks,